### PR TITLE
add @ when using dg

### DIFF
--- a/bdump.js
+++ b/bdump.js
@@ -79,7 +79,7 @@ function __collect_seg(n) {
     const Control = host.namespace.Debugger.Utility.Control;
 
     let r = {};
-    let line = Control.ExecuteCommand('dg ' + n).Last();
+    let line = Control.ExecuteCommand('dg @' + n).Last();
     // Sel        Base              Limit          Type    l ze an es ng Flags
     // ---- ----------------- ----------------- ---------- - -- -- -- -- --------
     // 0033 00000000`00000000 00000000`00000000 Code RE Ac 3 Nb By P  Lo 000002fb


### PR DESCRIPTION
Hello.
When I dumped, I often saw the error message like below.

 ```shell
[bdump] could not recover fs!
Error: Unable to set property 'base' of undefined or null reference [at bdump (line 73 col 5)]
 ```

This error occurs when executing `dg fs`. I don't know why this is happening, but using `@` can resolve this issue.

```shell
kd> r fs
fs=0053
kd> r @fs
fs=0053
kd> dg fs
                                                    P Si Gr Pr Lo
Sel        Base              Limit          Type    l ze an es ng Flags
---- ----------------- ----------------- ---------- - -- -- -- -- --------
A70DE520 Unable to get descriptor

kd> dg @fs
                                                    P Si Gr Pr Lo
Sel        Base              Limit          Type    l ze an es ng Flags
---- ----------------- ----------------- ---------- - -- -- -- -- --------
0053 00000000`00000000 00000000`00003c00 Data RW Ac 3 Bg By P  Nl 000004f3

kd> dg 0x53
                                                    P Si Gr Pr Lo
Sel        Base              Limit          Type    l ze an es ng Flags
---- ----------------- ----------------- ---------- - -- -- -- -- --------
0053 00000000`00000000 00000000`00003c00 Data RW Ac 3 Bg By P  Nl 000004f3
```

